### PR TITLE
GM-249 공용 컴포넌트 (Header, NavBar) 생성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,30 @@
-import { useState } from 'react'
+import Header from "./component/Header";
+import {Provider} from "react-redux";
+import {store} from "./store";
+import styled, {ThemeProvider} from "styled-components";
+import theme from "./theme";
+import NavBar from "./component/NavBar";
 
 function App() {
 
+    const Test = styled.div`
+      //background-color: black;
+      height: 2000px;
+    `
 
   return (
-    <h1>Project Init</h1>
+
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+            <div>
+              <Header/>
+                <Test/>
+              <NavBar/>
+            </div>
+        </ThemeProvider>
+      </Provider>
+
+
   )
 }
 

--- a/src/component/Header.tsx
+++ b/src/component/Header.tsx
@@ -1,0 +1,115 @@
+import styled from "styled-components";
+import theme from "../theme";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faAngleDown, faBarcode, faBars, faGear, faMagnifyingGlass, faQrcode} from "@fortawesome/free-solid-svg-icons";
+import {faBell, faCircleUser} from "@fortawesome/free-regular-svg-icons";
+import {useModeSelector} from "../store/mode";
+
+const HeaderBlock = styled.div`
+    height: 40px;
+    margin: 25px 20px 25px 25px;
+    display: flex;
+    justify-content: space-between;
+    font-family: ${theme.font.kor};
+    align-items: center;
+  font-size: 20px;
+
+
+`
+const HeaderTitle = styled.span`
+  position: relative;
+  font-weight: 600;
+`
+
+const HeaderAngleDown = styled(FontAwesomeIcon)`
+  font-size: 16px;
+  margin-left: 5px;
+  :hover{
+    cursor: pointer;
+  }
+`
+const IconBlock = styled.div`
+  display: flex;
+  justify-content: space-between;
+`
+const MarginedIcon = styled(FontAwesomeIcon)`
+    margin-left: 25px;
+  :hover{
+    cursor: pointer;
+  }
+`
+const Top = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right:0;
+
+`
+
+
+function Header(){
+
+    const mode = useModeSelector();
+
+    function createTitle() {
+        switch (mode) {
+            case "chat":
+                return <>
+                    <span>채팅</span>
+                </>;
+            case "my" :
+                return <></>
+           default :
+                return <>
+                    <span>서초3동</span>
+                    <HeaderAngleDown icon={faAngleDown}/>
+                </>;
+        }
+    }
+
+    function createIcon() {
+
+        switch (mode) {
+            case "chat":
+                return <>
+                    <MarginedIcon icon={faBarcode}/>
+                    <MarginedIcon icon={faBell}/>
+                </>;
+            case "my" :
+                return <><MarginedIcon icon={faGear}/></>
+            case "townlife":
+                return <>
+                    <MarginedIcon icon={faMagnifyingGlass}/>
+                    <MarginedIcon icon={faCircleUser}/>
+                    <MarginedIcon icon={faBell}/>
+                </>
+            default :
+                return <>
+                    <MarginedIcon icon={faMagnifyingGlass}/>
+                    <MarginedIcon icon={faBars}/>
+                    <MarginedIcon icon={faBell}/>
+                </>;
+        }
+
+    }
+
+
+    return (<>
+
+        <Top>
+            <HeaderBlock>
+                <HeaderTitle>
+                    {createTitle()}
+                </HeaderTitle>
+                <IconBlock>
+                    {createIcon()}
+                </IconBlock>
+            </HeaderBlock>
+            { mode === "my" ? "" : <hr/>}
+        </Top>
+
+    </>)
+}
+
+
+export default Header;

--- a/src/component/NavBar.tsx
+++ b/src/component/NavBar.tsx
@@ -1,0 +1,39 @@
+import styled from "styled-components";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faHouse, faLocationDot} from "@fortawesome/free-solid-svg-icons";
+import {faComments, faMap, faUser} from "@fortawesome/free-regular-svg-icons";
+import NavItemBlock from "./NavItemBlock";
+import {useDispatch} from "react-redux";
+import {MODE} from "../util/Constants";
+
+function NavBar(){
+
+    const NavBarBlock = styled.div`
+        height: 60px;
+        margin : 15px 32px 35px 45px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    `
+
+    const Bottom = styled.div`
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right:0;
+    `
+    return (<>
+        <Bottom>
+            <hr/>
+            <NavBarBlock>
+                <NavItemBlock itemIcon={faHouse} itemMode={MODE.HOME}/>
+                <NavItemBlock itemIcon={faMap} itemMode={MODE.TOWNLIFE}/>
+                <NavItemBlock itemIcon={faLocationDot} itemMode={MODE.NEIGHBOR}/>
+                <NavItemBlock itemIcon={faComments} itemMode={MODE.CHAT}/>
+                <NavItemBlock itemIcon={faUser} itemMode={MODE.MY}/>
+            </NavBarBlock>
+        </Bottom>
+    </>)
+}
+
+export default NavBar;

--- a/src/component/NavItemBlock.tsx
+++ b/src/component/NavItemBlock.tsx
@@ -1,0 +1,54 @@
+import {faHouse} from "@fortawesome/free-solid-svg-icons";
+import styled from "styled-components";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {IconDefinition} from "@fortawesome/free-brands-svg-icons";
+import {ModeProps} from "../util/Constants";
+import {useDispatch} from "react-redux";
+import {SELECT} from "../store/mode";
+
+const NavItemWrapper = styled.div`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      :hover{
+        cursor: pointer;
+      }
+    `
+const NavItemIcon = styled(FontAwesomeIcon)`
+        font-size: 26px;
+        margin-bottom: 5px;
+    `
+const NavItemSpan = styled.span`
+      font-size: 14px;
+      font-weight: bold;
+    `
+
+interface NavItemBlockProps{
+    itemIcon : IconDefinition
+    itemMode : ModeProps;
+
+}
+
+
+
+function NavItemBlock({itemIcon, itemMode}:NavItemBlockProps){
+
+    const dispatch = useDispatch();
+
+    const navItemClicked = () => {
+        dispatch(SELECT(itemMode.eng))
+    }
+
+    return (
+        <>
+            <NavItemWrapper onClick={navItemClicked}>
+                <NavItemIcon icon={itemIcon}/>
+                <NavItemSpan>{itemMode.kor}</NavItemSpan>
+            </NavItemWrapper>
+
+        </>
+    )
+
+}
+
+export default NavItemBlock;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,49 @@
+@import url('https://fonts.googleapis.com/css2?family=Cute+Font&family=Dongle:wght@300;400;700&family=Jua&family=Nabla&family=Noto+Sans+KR&family=Permanent+Marker&family=Single+Day&family=Ubuntu:wght@400;500&display=swap');
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+    box-sizing: border-box;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+    display: block;
+}
+body {
+    line-height: 1;
+}
+ol, ul {
+    list-style: none;
+}
+blockquote, q {
+    quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+    content: '';
+    content: none;
+}
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+hr{
+    margin: 0
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-
+import '/src/index.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,11 @@
+import {configureStore} from "@reduxjs/toolkit";
+import {modeSlice} from "./mode";
+
+export const store = configureStore({
+    reducer: {
+        mode : modeSlice.reducer
+
+    },
+})
+
+export type RootState = ReturnType<typeof store.getState>

--- a/src/store/mode.ts
+++ b/src/store/mode.ts
@@ -1,0 +1,17 @@
+import {createSlice} from "@reduxjs/toolkit";
+import {useSelector} from "react-redux";
+import {RootState} from "./index";
+import {MODE} from "../util/Constants";
+
+export const modeSlice = createSlice({
+    name: 'mode',
+    initialState: MODE.HOME.eng,
+    reducers: {
+        SELECT: (state,action) => {
+            return action.payload;
+        },
+    },
+})
+export const useModeSelector = () =>
+    useSelector((state: RootState) => state.mode)
+export const {SELECT} = modeSlice.actions;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,9 @@
+
+const font = {
+    kor : "'Noto Sans KR', sans-serif"
+}
+
+
+export default {
+    font
+}

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -1,0 +1,37 @@
+interface ModeType{
+    HOME : ModeProps,
+    TOWNLIFE : ModeProps,
+    CHAT : ModeProps,
+    MY : ModeProps,
+    NEIGHBOR : ModeProps
+}
+interface ModeProps{
+    eng : string,
+    kor : string
+}
+
+const MODE:ModeType = {
+    HOME : {
+        eng :'home',
+        kor : '홈'
+    },
+    TOWNLIFE : {
+        eng : 'townlife',
+        kor : "동네생활"
+    },
+    CHAT : {
+     eng : 'chat',
+     kor : '채팅'   
+    },
+    MY : {
+     eng : 'my',
+     kor : "나의 당근"   
+    },
+    NEIGHBOR : {
+     eng : "neighbor",
+     kor : "내 근처"
+    }
+}
+
+export {MODE}
+export type { ModeProps }


### PR DESCRIPTION
# GM-249 공용 컴포넌트 (Header, NavBar) 생성
## Description
> 공용으로 사용되는 컴포넌트인 헤더와 네비게이션 바를 만들었다.

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [X] View
- [ ] Other... Please describe :

## Issues
헤더와 네비게이션 바를 만들었음.
헤더와 네비게이션 바는 fixed하게 설정하여 위치가 고정된다.
헤더는 redux에 저장된 mode에 따라서 변동되며, navbar를 선택하면 mode가 변경된다.

![image](https://user-images.githubusercontent.com/76154390/218955536-7d265da2-1495-472c-8199-97b9472a7733.png)


어떤 네비게이션을 클릭했을 때 누가 클릭되었다고 표시해주고 싶은데 흰-> 검으로 바꾸고 싶은데 몇몇 아이콘이 흰색이 무료가 아니여서 사용할 수가 없음. 어떻게 하는게 좋을까 ?

## Think About..  

확실히 어떤 화면인지 안보이는 게 마음에 걸린다.

## Conclusion  
> 생긴건 낫베드인데?
