### PR TITLE
GM-266 중고거래 리스트 뷰 제작

### DIFF
--- a/src/component/main/Header.tsx
+++ b/src/component/main/Header.tsx
@@ -1,18 +1,19 @@
 import styled from "styled-components";
-import theme from "../theme";
+import theme from "../../theme";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faAngleDown, faBarcode, faBars, faGear, faMagnifyingGlass, faQrcode} from "@fortawesome/free-solid-svg-icons";
 import {faBell, faCircleUser} from "@fortawesome/free-regular-svg-icons";
-import {useModeSelector} from "../store/mode";
+import {useModeSelector} from "../../store/mode";
 
 const HeaderBlock = styled.div`
-    height: 40px;
-    margin: 25px 20px 25px 25px;
-    display: flex;
-    justify-content: space-between;
-    font-family: ${theme.font.kor};
-    align-items: center;
+  height: 90px;
+  padding: 25px 20px 25px 25px;
+  display: flex;
+  justify-content: space-between;
+  font-family: ${theme.font.kor};
+  align-items: center;
   font-size: 20px;
+  background-color: white;
 
 
 `
@@ -24,7 +25,7 @@ const HeaderTitle = styled.span`
 const HeaderAngleDown = styled(FontAwesomeIcon)`
   font-size: 16px;
   margin-left: 5px;
-  :hover{
+  :hover {
     cursor: pointer;
   }
 `
@@ -33,8 +34,9 @@ const IconBlock = styled.div`
   justify-content: space-between;
 `
 const MarginedIcon = styled(FontAwesomeIcon)`
-    margin-left: 25px;
-  :hover{
+  margin-left: 25px;
+
+  :hover {
     cursor: pointer;
   }
 `
@@ -42,12 +44,12 @@ const Top = styled.div`
   position: fixed;
   top: 0;
   left: 0;
-  right:0;
+  right: 0;
 
 `
 
 
-function Header(){
+function Header() {
 
     const mode = useModeSelector();
 
@@ -59,7 +61,7 @@ function Header(){
                 </>;
             case "my" :
                 return <></>
-           default :
+            default :
                 return <>
                     <span>서초3동</span>
                     <HeaderAngleDown icon={faAngleDown}/>
@@ -105,7 +107,7 @@ function Header(){
                     {createIcon()}
                 </IconBlock>
             </HeaderBlock>
-            { mode === "my" ? "" : <hr/>}
+            {mode === "my" ? "" : <hr/>}
         </Top>
 
     </>)

--- a/src/component/main/MainContent.tsx
+++ b/src/component/main/MainContent.tsx
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+import UsedItemList from "./UsedItemList";
+
+const MainBlock = styled.div`
+    padding-top: 100px;
+    height: 2000px;
+`
+
+function MainContent(){
+
+    return (
+        <>
+            <MainBlock>
+             <UsedItemList/>
+            </MainBlock>
+        </>
+    )
+}
+
+export default MainContent;

--- a/src/component/main/NavBar.tsx
+++ b/src/component/main/NavBar.tsx
@@ -4,24 +4,26 @@ import {faHouse, faLocationDot} from "@fortawesome/free-solid-svg-icons";
 import {faComments, faMap, faUser} from "@fortawesome/free-regular-svg-icons";
 import NavItemBlock from "./NavItemBlock";
 import {useDispatch} from "react-redux";
-import {MODE} from "../util/Constants";
+import {MODE} from "../../util/Constants";
 
 const NavBarBlock = styled.div`
-        height: 60px;
-        margin : 15px 32px 35px 45px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-    `
+  height: 90px;
+  //padding : 15px 32px 35px 45px;
+  padding: 15px 0px 15px 0px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  background-color: white;
+`
 
 const Bottom = styled.div`
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right:0;
-    `
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+`
 
-function NavBar():JSX.Element{
+function NavBar(): JSX.Element {
 
 
     return (<>

--- a/src/component/main/NavItemBlock.tsx
+++ b/src/component/main/NavItemBlock.tsx
@@ -2,9 +2,9 @@ import {faHouse} from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {IconDefinition} from "@fortawesome/free-brands-svg-icons";
-import {ModeProps} from "../util/Constants";
+import {ModeProps} from "../../util/Constants";
 import {useDispatch} from "react-redux";
-import {SELECT} from "../store/mode";
+import {SELECT} from "../../store/mode";
 
 const NavItemWrapper = styled.div`
         display: flex;

--- a/src/component/main/UsedItem.tsx
+++ b/src/component/main/UsedItem.tsx
@@ -1,0 +1,96 @@
+import gaaji from "../../assets/gaaji.png";
+import {faHeart} from "@fortawesome/free-regular-svg-icons";
+import styled from "styled-components";
+import theme from "../../theme";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {compareLocalDateTimeToNow} from "../../util/LocalDateTimeConverter";
+
+const UsedItemWrapper = styled.div`
+  display: flex;
+  margin: 20px 0px;
+  justify-content: space-between;
+  align-items: center;
+`
+const UsedItemImageWrapper = styled.div`
+  width: 100px;
+  height: 100px;
+  border-radius: 10px;
+  border: 1px solid ${theme.color.gray};
+  margin-right: 25px;
+
+`
+const UsedItemImage = styled.img`
+  object-fit: fill;
+  width: 100%;
+`
+const UsedItemContent = styled.div`
+  width: calc(100% - 100px);
+  font-family: ${theme.font.kor};
+`
+const UsedItemTitle = styled.div`
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 8px;
+`
+const UsedItemSub = styled.div`
+  font-size: 12px;
+  color: gray;
+  margin-bottom: 10px;
+`
+const UsedItemPrice = styled.div`
+  font-weight: bold;
+`
+const UsedItemInterestWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  color: gray;
+  align-items: center;
+`
+const UsedItemInterestIcon = styled(FontAwesomeIcon)`
+  margin-right: 3px;
+  position: relative;
+  top: 1px;
+`
+
+const Divider = styled.hr`
+  
+  background-color: ${theme.color.gray};
+`
+
+interface UsedItemProps {
+    postId: string;
+    imgUrl: string;
+    title: string;
+    address: string;
+    createdAt: string;
+    price: number;
+    interestCount: number;
+}
+
+function UsedItem({postId, imgUrl, title,address, createdAt, price, interestCount}: UsedItemProps) {
+
+    console.log(title.substring(0,24))
+
+
+    return (
+        <>
+            <UsedItemWrapper>
+                <UsedItemImageWrapper>
+                    <UsedItemImage src={imgUrl} alt={"haha"}/>
+                </UsedItemImageWrapper>
+                <UsedItemContent>
+                    <UsedItemTitle>{title.length > 24 ? `${title.substring(0,24)}...` : title}</UsedItemTitle>
+                    <UsedItemSub>{address} · {compareLocalDateTimeToNow(createdAt)}</UsedItemSub>
+                    <UsedItemPrice>{price.toLocaleString()}원</UsedItemPrice>
+                    <UsedItemInterestWrapper>
+                        <UsedItemInterestIcon icon={faHeart}/>
+                        <span>{interestCount}</span>
+                    </UsedItemInterestWrapper>
+                </UsedItemContent>
+            </UsedItemWrapper>
+            <Divider/>
+        </>
+    )
+}
+
+export default UsedItem;

--- a/src/component/main/UsedItemList.tsx
+++ b/src/component/main/UsedItemList.tsx
@@ -1,0 +1,39 @@
+import styled from "styled-components";
+import UsedItem from "./UsedItem";
+import {useState} from "react";
+import {createDummyUsedItemData, UsedItemPostList} from "../../util/Dummy";
+
+const UsedItemListWrapper = styled.div`
+  margin: 20px;
+`
+
+
+function UsedItemList() {
+    const dummy_data = createDummyUsedItemData();
+
+
+    return (
+        <>
+
+            <UsedItemListWrapper>
+                {
+                    dummy_data.map(d => {
+                        return <UsedItem
+                            key={d.postListRetirveResponse.previewPost.postId}
+                            imgUrl={d.postListRetirveResponse.previewPost.representPictureUrl}
+                            postId={d.postListRetirveResponse.previewPost.postId}
+                            title={d.postListRetirveResponse.previewPost.title}
+                            address={d.postListRetirveResponse.previewPost.address}
+                            createdAt={d.postListRetirveResponse.previewPost.createdAt}
+                            price={d.postListRetirveResponse.previewPost.price}
+                            interestCount={d.postListRetirveResponse.previewPostCount.interestCount}
+                        />
+                    })
+                }
+            </UsedItemListWrapper>
+
+        </>
+    )
+}
+
+export default UsedItemList;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,16 +1,14 @@
-import Header from "../component/Header";
-import NavBar from "../component/NavBar";
+import Header from "../component/main/Header";
+import NavBar from "../component/main/NavBar";
 import styled from "styled-components";
+import MainContent from "../component/main/MainContent";
 
-const Test = styled.div`
-      height: 2000px;
-    `
 
 function Main(){
 
     return (<>
         <Header/>
-        <Test/>
+        <MainContent/>
         <NavBar/>
     </>)
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -5,7 +5,8 @@ const font = {
 const color = {
     gaaji : "#8C42B3",
     kakao : "#FAE200",
-    naver : "#03C75A"
+    naver : "#03C75A",
+    gray : "rgba(0,0,0,0.1)"
 }
 
 export default {

--- a/src/util/Dummy.ts
+++ b/src/util/Dummy.ts
@@ -1,0 +1,45 @@
+
+interface UsedItemPost{
+    previewPost : {
+          postId : string;
+          representPictureUrl : string;
+          title : string;
+          address : string;
+          createdAt : string;
+          price : number;
+    }
+    previewPostCount : {
+        interestCount : number;
+        viewCount : number;
+    }
+}
+interface UsedItemPostList{
+    postListRetirveResponse : UsedItemPost
+}
+
+const createDummyUsedItemData = () => {
+    const dummy:UsedItemPostList[] = [];
+    for (let i = 0; i < 10; i++) {
+        dummy.push({
+            postListRetirveResponse: {
+                previewPost : {
+                    postId: `asdasd ${i}`,
+                    representPictureUrl : "https://todoay-picture.s3.ap-northeast-2.amazonaws.com/gaaji/fd308fa8-f9c1-4e2c-8a35-4c0816b51f23gajji.png",
+                    title : `테스트 ${i+1}`,
+                    address : `서초 ${i+1}동`,
+                    createdAt : `2023-02-15T22:52:49.954301600`,
+                    price : 30000
+                },
+                previewPostCount : {
+                    interestCount : 10,
+                    viewCount : 10
+                }
+            }
+        })
+    }
+    return dummy;
+
+}
+
+export {createDummyUsedItemData};
+export type { UsedItemPostList };

--- a/src/util/LocalDateTimeConverter.ts
+++ b/src/util/LocalDateTimeConverter.ts
@@ -1,0 +1,30 @@
+function convertLocalDateTime(localDateTime:string){
+    return new Date(localDateTime.substring(0,19));
+}
+function compareLocalDateTimeToNow(localDateTime:string) : string{
+    const target = convertLocalDateTime(localDateTime);
+    const now = new Date();
+
+    const gap = (now.getTime() - target.getTime())/1000;
+
+    // 분 60
+    // 시 60 * 60
+    // 하루 3600 * 24
+    // 달 60 * 60 * 24 * 30
+
+    if(now.getTime() < target.getTime())
+        console.error("현재보다 더 이후에 생성된 게시글이 존재할 수 없습니다.")
+    if(gap < 60)
+        return `${gap}초 전`
+    if(gap < 3600)
+        return `${Math.floor(gap/60)}분 전`
+    if(gap < 3600 * 24)
+        return `${Math.floor(gap/3600)}시간 전`
+    if(gap < 3600 * 24 * 30)
+        return `${Math.floor(gap/3600 * 24)}일 전`
+    if(gap > 3600 * 24 * 30)
+        return `${Math.floor(gap/3600 * 24 * 30)}달 전`
+    return "";
+}
+
+export{compareLocalDateTimeToNow}


### PR DESCRIPTION

# GM-266 중고거래 리스트 뷰 제작
## Description
> 중고거래 리스트에 대한 뷰를 제작하고, 메인 화면 헤더, 네비게이션 바 css를 수정해주었다.

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [X] Other... Please describe : View


## Issues

 - 중고거래 리스트 뷰 제작
 - 메인 화면 헤더, 네비게이션 바 백그라운드 색 추가
 - 네비게이션 바 좌우 패딩 삭제
 - Java의 LocalDateTime Convert 추가
 - 중고거래 더미 데이터 추가

### 화면

![image](https://user-images.githubusercontent.com/76154390/219051661-4a9ab9fb-71e5-4086-845d-508df90d9a11.png)

## Conclusion  
> 
